### PR TITLE
Eliminate zero-width Unicode characters used in MediaWiki

### DIFF
--- a/general/ip-range-calc.html
+++ b/general/ip-range-calc.html
@@ -87,7 +87,7 @@
 					cnt = 128;
 				}
 
-				let ipL = this.inputText.split("\n").map(s => s.trim()).filter(ip => ip);
+				let ipL = this.inputText.split("\n").map(s => s.replace(/[\u200B-\u200F]/, "").trim()).filter(ip => ip);
 
 				// validate and parse IP addresses from user input
 				let addrs = [];


### PR DESCRIPTION
Problem:
A one-line input "  ‎176.12.82.87"  should result in "176.12.82.87/32", but an error is displayed instead:
`ERROR: '‎176.12.82.87' is not a valid IPv4 address, please fix this before proceeding.`
This can happen when copying an IP address from MediaWiki.

Originally reported in https://www.wikidata.org/w/index.php?title=Wikidata:Administrators%27_noticeboard&diff=next&oldid=1355171074&diffmode=source

Solution:
Remove applicable characters ([left-to-right marks](https://en.wikipedia.org/wiki/Left-to-right_mark) and [zero-width spaces](https://en.wikipedia.org/wiki/Zero-width_space) and others) from input when trimming.

